### PR TITLE
Initialize SinkHound tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # SinkHound
-A Git-aware static analysis tool for tracking dangerous code patterns through commit history
+
+SinkHound is a security focused tool that scans the commit history of a Git repository to detect dangerous functions or code patterns known as *sinks*. Unlike traditional static analyzers that operate on the current code base, SinkHound inspects the diffs of every commit so you can trace when risky code was introduced.
+
+## Features
+
+- **Commit-aware sink tracing** – scans added lines in each commit
+- **Customizable rule sets** – define sinks in YAML with descriptions and risk scores
+- **Human-readable output** – shows the commit, sink description and offending line
+- **Multi-format reporting** – console output today, JSON/HTML in the future
+
+## Quick start
+
+```bash
+pip install -r requirements.txt
+python -m sinkhound.cli scan --sinks sinks/php.yml --branch main --repo https://github.com/codingo/NoSQLMap
+```
+
+The command above will clone the repository, iterate over its commits and report any lines matching the sink rules defined in `sinks/php.yml`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sinkhound"
+version = "0.1.0"
+readme = "README.md"
+dependencies = [
+    "GitPython>=3.1",
+    "PyYAML>=6.0",
+]
+
+[project.scripts]
+sinkhound = "sinkhound.cli:main"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+GitPython>=3.1
+PyYAML>=6.0

--- a/sinkhound/__init__.py
+++ b/sinkhound/__init__.py
@@ -1,0 +1,5 @@
+"""SinkHound package."""
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/sinkhound/cli.py
+++ b/sinkhound/cli.py
@@ -1,0 +1,28 @@
+"""Command line interface for SinkHound."""
+
+import argparse
+from pathlib import Path
+
+from .scanner import scan_repository
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="Scan git history for dangerous patterns")
+    subparsers = parser.add_subparsers(dest="command")
+
+    scan = subparsers.add_parser("scan", help="Scan a repository")
+    scan.add_argument("--sinks", required=True, type=Path, help="YAML file with sink definitions")
+    scan.add_argument("--branch", required=True, help="Branch to scan")
+    scan.add_argument("--repo", required=True, help="Repository URL")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "scan":
+        scan_repository(args.repo, args.branch, args.sinks)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/sinkhound/scanner.py
+++ b/sinkhound/scanner.py
@@ -1,0 +1,54 @@
+"""Core scanning functionality."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterable, List
+
+from git import Repo
+
+from .sinks import SinkConfig, SinkRule
+
+
+def clone_repo(url: str, branch: str) -> Repo:
+    temp_dir = tempfile.mkdtemp(prefix="sinkhound-")
+    repo = Repo.clone_from(url, temp_dir, branch=branch)
+    return repo
+
+
+def iter_commits(repo: Repo, branch: str) -> Iterable:
+    return repo.iter_commits(branch, reverse=True)
+
+
+def scan_commit(commit, rules: List[SinkRule]) -> List[str]:
+    """Scan a commit and return matching lines."""
+    matches = []
+    parents = commit.parents
+    if not parents:
+        return matches
+    diff = parents[0].diff(commit, create_patch=True)
+    for diff_item in diff:
+        for line in diff_item.diff.decode("utf-8", errors="ignore").splitlines():
+            if not line.startswith("+"):
+                continue
+            for rule in rules:
+                if re.search(rule.pattern, line):
+                    matches.append(
+                        f"{commit.hexsha[:7]} {diff_item.b_path}: {line[1:].strip()}"
+                    )
+    return matches
+
+
+def scan_repository(repo_url: str, branch: str, sink_file: Path) -> None:
+    repo = clone_repo(repo_url, branch)
+    cfg = SinkConfig(sink_file)
+    for commit in iter_commits(repo, branch):
+        matches = scan_commit(commit, cfg.rules)
+        if matches:
+            print(f"Commit {commit.hexsha}: {commit.summary}")
+            for m in matches:
+                print(f"  {m}")
+

--- a/sinkhound/sinks.py
+++ b/sinkhound/sinks.py
@@ -1,0 +1,35 @@
+"""Utilities for loading sink definitions from YAML."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import yaml
+
+
+@dataclass
+class SinkRule:
+    pattern: str
+    description: str
+    risk: int
+
+
+class SinkConfig:
+    """Loads sink rules from a YAML file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.rules: List[SinkRule] = []
+        self.load()
+
+    def load(self) -> None:
+        data = yaml.safe_load(self.path.read_text())
+        for item in data.get("sinks", []):
+            self.rules.append(
+                SinkRule(
+                    pattern=item.get("pattern"),
+                    description=item.get("description", ""),
+                    risk=int(item.get("risk", 0)),
+                )
+            )
+

--- a/sinks/php.yml
+++ b/sinks/php.yml
@@ -1,0 +1,7 @@
+sinks:
+  - pattern: "unserialize\\("
+    description: "Usage of unserialize function"
+    risk: 5
+  - pattern: "eval\\("
+    description: "Usage of eval function"
+    risk: 10

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import tempfile
+
+from git import Repo
+
+from sinkhound.sinks import SinkConfig
+from sinkhound.scanner import iter_commits, scan_commit
+
+
+def create_repo() -> Path:
+    tmp = Path(tempfile.mkdtemp())
+    repo = Repo.init(tmp)
+    (tmp / "a.py").write_text("print('hello')\n")
+    repo.index.add(["a.py"])
+    repo.index.commit("initial commit")
+    (tmp / "a.py").write_text("eval('danger')\n")
+    repo.index.add(["a.py"])
+    repo.index.commit("add eval")
+    return tmp
+
+
+def test_scan_detects_eval():
+    repo_path = create_repo()
+    repo = Repo(repo_path)
+    cfg = SinkConfig(Path("sinks/php.yml"))
+    commits = list(iter_commits(repo, "master"))
+    found = False
+    for commit in commits:
+        matches = scan_commit(commit, cfg.rules)
+        if matches:
+            found = True
+            break
+    assert found
+


### PR DESCRIPTION
## Summary
- implement base SinkHound tool
- add CLI entrypoint and repo scanner
- support YAML-based sink configuration
- provide example PHP sink rules
- document usage in README
- configure packaging via `pyproject.toml`
- include basic unit test

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527f542eb88326ba6bc0c08b0bf3d6