### PR TITLE
Add CLI entrypoint and usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ SinkHound is a security focused tool that scans the commit history of a Git repo
 ## Quick start
 
 ```bash
-pip install -r requirements.txt
-python -m sinkhound.cli scan --sinks sinks/php.yml --branch main --repo https://github.com/codingo/NoSQLMap
+# install the command line interface
+pip install .
+
+# run a scan using the installed `sinkhound` command
+sinkhound scan --sinks sinks/php.yml --branch main --repo https://github.com/codingo/NoSQLMap
 ```
 
 The command above will clone the repository, iterate over its commits and report any lines matching the sink rules defined in `sinks/php.yml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ dependencies = [
 [project.scripts]
 sinkhound = "sinkhound.cli:main"
 
+[tool.setuptools.packages.find]
+include = ["sinkhound*"]
+

--- a/sinkhound/__main__.py
+++ b/sinkhound/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `python -m sinkhound` via `sinkhound/__main__.py`
- update packaging to only include `sinkhound` package
- document installation and new `sinkhound` command in README

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b8fcd5ec8326a0b98527e1a6c26d