### PR TITLE
Add PHP serialization, inclusion & SSRF rules

### DIFF
--- a/sinks/php.yml
+++ b/sinks/php.yml
@@ -2,6 +2,15 @@ sinks:
   - pattern: "unserialize\\("
     description: "Usage of unserialize function"
     risk: 5
+  - pattern: "serialize\\("
+    description: "Usage of serialize function"
+    risk: 3
   - pattern: "eval\\("
     description: "Usage of eval function"
     risk: 10
+  - pattern: "(?:include|include_once|require|require_once)\\s*\\("
+    description: "File inclusion functions"
+    risk: 7
+  - pattern: "(?:curl_exec|curl_multi_exec|file_get_contents|fopen|fsockopen|pfsockopen|stream_socket_client)\\("
+    description: "Potential SSRF through HTTP requests"
+    risk: 8


### PR DESCRIPTION
## Summary
- expand PHP sink rules to cover more serialization calls
- add file inclusion functions
- add SSRF-related network functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852be3733208326b095c8f1e5044e80