### PR TITLE
Refine SSRF detection patterns

### DIFF
--- a/sinks/php.yml
+++ b/sinks/php.yml
@@ -11,6 +11,6 @@ sinks:
   - pattern: "(?:include|include_once|require|require_once)\\s*\\("
     description: "File inclusion functions"
     risk: 7
-  - pattern: "(?:curl_exec|curl_multi_exec|file_get_contents|fopen|fsockopen|pfsockopen|stream_socket_client)\\("
-    description: "Potential SSRF through HTTP requests"
+  - pattern: "(?:curl_exec|curl_multi_exec|file_get_contents|fopen|fsockopen|pfsockopen|stream_socket_client)\\s*\\(\\s*(?!['\"'][^$'\"']*['\"'])"
+    description: "Potential SSRF when variable input is used"
     risk: 8

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -19,6 +19,18 @@ def create_repo() -> Path:
     return tmp
 
 
+def create_repo_file_reads() -> Path:
+    tmp = Path(tempfile.mkdtemp())
+    repo = Repo.init(tmp)
+    (tmp / "a.php").write_text('<?php\n$content = file_get_contents("test.txt");\n')
+    repo.index.add(["a.php"])
+    repo.index.commit("initial commit")
+    (tmp / "a.php").write_text('<?php\n$content = file_get_contents($file);\n')
+    repo.index.add(["a.php"])
+    repo.index.commit("use variable input")
+    return tmp
+
+
 def test_scan_detects_eval():
     repo_path = create_repo()
     repo = Repo(repo_path)
@@ -31,4 +43,14 @@ def test_scan_detects_eval():
             found = True
             break
     assert found
+
+
+def test_dynamic_file_read_flagged():
+    repo_path = create_repo_file_reads()
+    repo = Repo(repo_path)
+    cfg = SinkConfig(Path("sinks/php.yml"))
+    commits = list(iter_commits(repo, "master"))
+    results = [scan_commit(c, cfg.rules) for c in commits]
+    assert not results[0]
+    assert results[1]
 


### PR DESCRIPTION
## Summary
- update PHP sink patterns to only flag dynamic targets
- add regression test to ensure constant strings are not flagged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c318ac7083269c83a2d10e0d563b