### PR TITLE
Add ignore extension option and improved output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SinkHound is a security focused tool that scans the commit history of a Git repo
 - **Commit-aware sink tracing** – scans added lines in each commit
 - **Customizable rule sets** – define sinks in YAML with descriptions and risk scores
 - **Human-readable output** – shows the commit, sink description and offending line
+- **File extension filtering** – skip scanning specific extensions with `--ignore-ext`
 - **Multi-format reporting** – console output today, JSON/HTML in the future
 
 ## Quick start
@@ -16,7 +17,7 @@ SinkHound is a security focused tool that scans the commit history of a Git repo
 pip install .
 
 # run a scan using the installed `sinkhound` command
-sinkhound scan --sinks sinks/php.yml --branch main --repo https://github.com/codingo/NoSQLMap
+sinkhound scan --sinks sinks/php.yml --branch main --repo https://github.com/codingo/NoSQLMap --ignore-ext .js
 ```
 
 The command above will clone the repository, iterate over its commits and report any lines matching the sink rules defined in `sinks/php.yml`.

--- a/sinkhound/cli.py
+++ b/sinkhound/cli.py
@@ -14,11 +14,17 @@ def main(argv=None) -> None:
     scan.add_argument("--sinks", required=True, type=Path, help="YAML file with sink definitions")
     scan.add_argument("--branch", required=True, help="Branch to scan")
     scan.add_argument("--repo", required=True, help="Repository URL")
+    scan.add_argument(
+        "--ignore-ext",
+        nargs="*",
+        default=[],
+        help="File extensions to skip during scanning (e.g. .js .css)",
+    )
 
     args = parser.parse_args(argv)
 
     if args.command == "scan":
-        scan_repository(args.repo, args.branch, args.sinks)
+        scan_repository(args.repo, args.branch, args.sinks, ignore_ext=args.ignore_ext)
     else:
         parser.print_help()
 

--- a/sinkhound/scanner.py
+++ b/sinkhound/scanner.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 from git import Repo
 
@@ -23,32 +23,56 @@ def iter_commits(repo: Repo, branch: str) -> Iterable:
     return repo.iter_commits(branch, reverse=True)
 
 
-def scan_commit(commit, rules: List[SinkRule]) -> List[str]:
+from dataclasses import dataclass
+
+
+@dataclass
+class ScanMatch:
+    """Details about a single sink match."""
+
+    path: str
+    line: str
+    description: str
+    risk: int
+
+
+def scan_commit(commit, rules: List[SinkRule], ignore_ext: Optional[List[str]] = None) -> List[ScanMatch]:
     """Scan a commit and return matching lines."""
-    matches = []
+    matches: List[ScanMatch] = []
     parents = commit.parents
     if not parents:
         return matches
     diff = parents[0].diff(commit, create_patch=True)
     for diff_item in diff:
+        if ignore_ext and any(diff_item.b_path.endswith(ext) for ext in ignore_ext):
+            continue
         for line in diff_item.diff.decode("utf-8", errors="ignore").splitlines():
             if not line.startswith("+"):
                 continue
             for rule in rules:
                 if re.search(rule.pattern, line):
                     matches.append(
-                        f"{commit.hexsha[:7]} {diff_item.b_path}: {line[1:].strip()}"
+                        ScanMatch(
+                            path=diff_item.b_path,
+                            line=line[1:].strip(),
+                            description=rule.description,
+                            risk=rule.risk,
+                        )
                     )
     return matches
 
 
-def scan_repository(repo_url: str, branch: str, sink_file: Path) -> None:
+def scan_repository(
+    repo_url: str, branch: str, sink_file: Path, ignore_ext: Optional[List[str]] = None
+) -> None:
     repo = clone_repo(repo_url, branch)
     cfg = SinkConfig(sink_file)
     for commit in iter_commits(repo, branch):
-        matches = scan_commit(commit, cfg.rules)
+        matches = scan_commit(commit, cfg.rules, ignore_ext=ignore_ext)
         if matches:
             print(f"Commit {commit.hexsha}: {commit.summary}")
             for m in matches:
-                print(f"  {m}")
+                print(
+                    f"  {m.path} -> {m.description} (risk {m.risk})\n    {m.line}"
+                )
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -4,7 +4,7 @@ import tempfile
 from git import Repo
 
 from sinkhound.sinks import SinkConfig
-from sinkhound.scanner import iter_commits, scan_commit
+from sinkhound.scanner import iter_commits, scan_commit, ScanMatch
 
 
 def create_repo() -> Path:
@@ -27,8 +27,18 @@ def test_scan_detects_eval():
     found = False
     for commit in commits:
         matches = scan_commit(commit, cfg.rules)
-        if matches:
+        if any(m.description == "Usage of eval function" for m in matches):
             found = True
             break
     assert found
+
+
+def test_ignore_extension_skips_file():
+    repo_path = create_repo()
+    repo = Repo(repo_path)
+    cfg = SinkConfig(Path("sinks/php.yml"))
+    commits = list(iter_commits(repo, "master"))
+    target_commit = commits[-1]
+    matches = scan_commit(target_commit, cfg.rules, ignore_ext=[".py"])
+    assert matches == []
 


### PR DESCRIPTION
## Summary
- refine scan output to show rule descriptions and risk levels
- add option to skip files by extension
- document the new option in README
- test ignoring extensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c373cfb88326acbc12e7facaed4e