### PR TITLE
Add progress logging and silent mode

### DIFF
--- a/sinkhound/cli.py
+++ b/sinkhound/cli.py
@@ -21,6 +21,12 @@ def main(argv=None) -> None:
         help="Comma separated list of extensions to scan (e.g. php,yaml)",
 
     )
+    scan.add_argument(
+        "-s",
+        "--silent",
+        action="store_true",
+        help="Suppress progress logging",
+    )
 
     args = parser.parse_args(argv)
 
@@ -38,6 +44,7 @@ def main(argv=None) -> None:
             args.branch,
             args.sinks,
             include_ext=include_ext,
+            silent=args.silent,
         )
 
     else:


### PR DESCRIPTION
## Summary
- add optional progress logs in `scan_repository`
- stop logging once results are printed
- support `-s/--silent` flag in CLI to disable the logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d0ae5ea48326b1c2b0d3a0283041