### PR TITLE
Add commit scan limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ SinkHound is a security focused tool that scans the commit history of a Git repo
 - **Customizable rule sets** – define sinks in YAML with descriptions and risk scores
 - **Human-readable output** – shows the commit, sink description and offending line
 - **File extension filtering** – only process files with certain extensions using `--include-ext`
+- **Commit range limiting** – scan only the last N commits using `--commits`
 
 - **Multi-format reporting** – console output today, JSON/HTML in the future
 
@@ -20,6 +21,9 @@ pip install .
 # run a scan using the installed `sinkhound` command
 
 sinkhound scan --sinks sinks/php.yml --branch main --repo https://github.com/codingo/NoSQLMap --include-ext php,yaml
+
+# limit to last 100 commits
+sinkhound scan --sinks sinks/php.yml --branch main --repo https://github.com/codingo/NoSQLMap --include-ext php,yaml -c 100
 
 ```
 

--- a/sinkhound/cli.py
+++ b/sinkhound/cli.py
@@ -7,25 +7,34 @@ from .scanner import scan_repository
 
 
 def main(argv=None) -> None:
-    parser = argparse.ArgumentParser(description="Scan git history for dangerous patterns")
+    parser = argparse.ArgumentParser(
+        description="Scan git history for dangerous patterns"
+    )
     subparsers = parser.add_subparsers(dest="command")
 
     scan = subparsers.add_parser("scan", help="Scan a repository")
-    scan.add_argument("--sinks", required=True, type=Path, help="YAML file with sink definitions")
+    scan.add_argument(
+        "--sinks", required=True, type=Path, help="YAML file with sink definitions"
+    )
     scan.add_argument("--branch", required=True, help="Branch to scan")
     scan.add_argument("--repo", required=True, help="Repository URL")
     scan.add_argument(
-
         "--include-ext",
         default="",
         help="Comma separated list of extensions to scan (e.g. php,yaml)",
-
     )
     scan.add_argument(
         "-s",
         "--silent",
         action="store_true",
         help="Suppress progress logging",
+    )
+    scan.add_argument(
+        "-c",
+        "--commits",
+        type=int,
+        default=None,
+        help="Limit the number of commits to scan",
     )
 
     args = parser.parse_args(argv)
@@ -45,6 +54,7 @@ def main(argv=None) -> None:
             args.sinks,
             include_ext=include_ext,
             silent=args.silent,
+            commit_limit=args.commits,
         )
 
     else:
@@ -53,4 +63,3 @@ def main(argv=None) -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -25,7 +25,7 @@ def create_repo_file_reads() -> Path:
     (tmp / "a.php").write_text('<?php\n$content = file_get_contents("test.txt");\n')
     repo.index.add(["a.php"])
     repo.index.commit("initial commit")
-    (tmp / "a.php").write_text('<?php\n$content = file_get_contents($file);\n')
+    (tmp / "a.php").write_text("<?php\n$content = file_get_contents($file);\n")
     repo.index.add(["a.php"])
     repo.index.commit("use variable input")
     return tmp
@@ -57,7 +57,6 @@ def test_scan_detects_eval():
     assert found
 
 
-
 def test_include_extension_filters_files():
 
     repo_path = create_repo()
@@ -68,7 +67,6 @@ def test_include_extension_filters_files():
 
     matches = scan_commit(target_commit, cfg.rules, include_ext=[".js"])
     assert matches == []
-
 
 
 def test_dynamic_file_read_flagged():
@@ -92,3 +90,8 @@ def test_deleted_files_are_ignored_with_include_ext():
     assert matches == []
 
 
+def test_iter_commits_respects_limit():
+    repo_path = create_repo()
+    repo = Repo(repo_path)
+    commits = list(iter_commits(repo, "master", max_count=1))
+    assert len(commits) == 1


### PR DESCRIPTION
## Summary
- allow selecting number of commits to scan via `-c/--commits`
- document the new option
- test that commit limit works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d1f699948326bcd57bee3b6ea9bb