### PR TITLE
Add dynamic sink rules for PHP includes and exec

### DIFF
--- a/sinks/php.yml
+++ b/sinks/php.yml
@@ -14,3 +14,9 @@ sinks:
   - pattern: "(?:curl_exec|curl_multi_exec|file_get_contents|fopen|fsockopen|pfsockopen|stream_socket_client)\\s*\\(\\s*(?!['\"'][^$'\"']*['\"'])"
     description: "Potential SSRF when variable input is used"
     risk: 8
+  - pattern: "(?:include|include_once|require|require_once)\\s*\\(\\s*(?!['\"'][^$'\"']*['\"'])"
+    description: "Dynamic file inclusion"
+    risk: 9
+  - pattern: "(?:exec|system|shell_exec|passthru|popen|pcntl_exec)\\s*\\(\\s*(?!['\"'][^$'\"']*['\"'])"
+    description: "Command execution with variable input"
+    risk: 10

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -43,6 +43,30 @@ def create_repo_with_deletion() -> Path:
     return tmp
 
 
+def create_repo_includes() -> Path:
+    tmp = Path(tempfile.mkdtemp())
+    repo = Repo.init(tmp)
+    (tmp / "a.php").write_text("<?php\ninclude 'test.php';\n")
+    repo.index.add(["a.php"])
+    repo.index.commit("initial commit")
+    (tmp / "a.php").write_text("<?php\ninclude($file);\n")
+    repo.index.add(["a.php"])
+    repo.index.commit("use variable include")
+    return tmp
+
+
+def create_repo_exec() -> Path:
+    tmp = Path(tempfile.mkdtemp())
+    repo = Repo.init(tmp)
+    (tmp / "a.php").write_text("<?php\nexec('ls');\n")
+    repo.index.add(["a.php"])
+    repo.index.commit("initial commit")
+    (tmp / "a.php").write_text("<?php\nexec($cmd);\n")
+    repo.index.add(["a.php"])
+    repo.index.commit("use variable exec")
+    return tmp
+
+
 def test_scan_detects_eval():
     repo_path = create_repo()
     repo = Repo(repo_path)
@@ -88,6 +112,26 @@ def test_deleted_files_are_ignored_with_include_ext():
 
     matches = scan_commit(target_commit, cfg.rules, include_ext=[".php"])
     assert matches == []
+
+
+def test_dynamic_include_flagged():
+    repo_path = create_repo_includes()
+    repo = Repo(repo_path)
+    cfg = SinkConfig(Path("sinks/php.yml"))
+    commits = list(iter_commits(repo, "master"))
+    results = [scan_commit(c, cfg.rules) for c in commits]
+    assert not results[0]
+    assert results[1]
+
+
+def test_dynamic_exec_flagged():
+    repo_path = create_repo_exec()
+    repo = Repo(repo_path)
+    cfg = SinkConfig(Path("sinks/php.yml"))
+    commits = list(iter_commits(repo, "master"))
+    results = [scan_commit(c, cfg.rules) for c in commits]
+    assert not results[0]
+    assert results[1]
 
 
 def test_iter_commits_respects_limit():


### PR DESCRIPTION
## Summary
- add high-risk patterns for dynamic includes and command execution
- test new rules with repositories using constant vs. variable input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ab5be6b883269a06d5f61ca94b20